### PR TITLE
Reslicing and bugfixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ TBA
 * Head motion plot from on eddy_qc outputs
 * Outlier plot from IRRLS outlier detection
 * Updated documentation
+* Option to reslice DWI with ``--reslice [x,y,z]``
 
 **Changed**:
 
@@ -24,6 +25,10 @@ TBA
   estimation. The new method now preserves all B0s, thereby allowing
   faster EPI distortion correction without degrading DTI/DKI maps.
 * Documentation moved to ReadTheDocs
+* Moved B0 production module from designer.preprocessing.brainmask to
+  a separate function at ``designer.preprocessing.extractmeanbzero()`` 
+  that gets called by PyDesigner main. This allows a B0.nii to be
+  produced regardless of the ``--mask`` flag.
 
 **Removed**:
 

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -820,3 +820,77 @@ def epiboost(input, output, num=1, nthreads=None, force=False,
                         'TOPUP B0 indices. See above for errors.')
     # Remove temp files
     os.remove(fname_bzero)
+
+def reslice(input, output, voxel, interp='linear', nthreads=None,
+            force=False, verbose=False):
+    """
+    Reslices input image to target voxel size
+
+    Parameters
+    ----------
+    input : str
+        Path to input .mif file
+    output : str
+        Path to output .mif file
+    voxel : float or tuple of float
+        x, y, z voxel size in mm
+    interp : str, {'linear', 'nearest', 'cubic' , 'sinc'}, optional
+        set the interpolation method to use when resizing (Default: 
+        'linear')
+    nthreads : int, optional
+        Specify the number of threads to use in processing
+        (Default: all available threads)
+    force : bool, optional
+        Force overwrite of output files if pre-existing
+        (Default:False)
+    verbose : bool, optional
+        Specify whether to print console output (Default: False)
+
+    Returns
+    -------
+    None; writes out file
+    """
+    if not op.exists(input):
+        raise OSError('Input path does not exist. Please ensure that '
+                      'the folder or file specified exists.')
+    if op.splitext(output)[-1] != '.mif':
+        raise OSError('Output should be specified as a .mif file.')
+    if not op.exists(op.dirname(output)):
+        raise OSError('Specifed directory for output file {} does not '
+                      'exist. Please ensure that this is a valid '
+                      'directory.'.format(op.dirname(output)))
+    if not isinstance(voxel, str):
+        raise Exception('Voxel size needs to be defined as a string '
+                        ' of three values')
+    if len(voxel.split(',')) != 3:
+        raise Exception('Please specify voxel size for each axis '
+                        'x, y, and z i.e. "3,3,3" for 3 mm isotropic')
+    if not isinstance(interp, str):
+        raise Exception('Interpolation method needs to be specified '
+                        'as a string')
+    if interp not in ('linear', 'nearest', 'cubic', 'sinc'):
+        raise Exception('User specified interpoaltion method {} is '
+                        'not a valid option'.format(interp))
+    if not (nthreads is None):
+        if not isinstance(nthreads, int):
+            raise Exception('Please specify the number of threads as an '
+                            'integer.')
+    if not isinstance(force, bool):
+        raise Exception('Please specify whether forced overwrite is True '
+                        'or False.')
+    if not isinstance(verbose, bool):
+        raise Exception('Please specify whether verbose is True or False.')
+    arg = ['mrresize']
+    if force:
+        arg.append('-force')
+    if not verbose:
+        arg.append('-quiet')
+    if not (nthreads is None):
+        arg.extend(['-nthreads', nthreads])
+    arg.extend(['-voxel', voxel])
+    arg.extend(['-interp', interp])
+    arg.extend([input, output])
+    completion = subprocess.run(arg)
+    if completion.returncode != 0:
+        raise Exception('EPIBOOST: failed to extract specified '
+                        'TOPUP B0 indices. See above for errors.')

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -653,6 +653,59 @@ def extractbzero(input, output, nthreads=None, force=False,
         raise Exception('Unable to extract B0s from DWI for computation '
                         'of brain mask. See above for errors.')
 
+def extractmeanbzero(input, output, nthreads=None, force=False,
+              verbose=False):
+    """
+    Extracts average B0 from all B0 shells.
+
+    Parameters
+    ----------
+    input : str
+        Path to input .mif file
+    output : str
+        Path to output .mif or .nii file
+    nthreads : int, optional
+        Specify the number of threads to use in processing
+        (Default: all available threads)
+    force : bool, optional
+        Force overwrite of output files if pre-existing
+        (Default:False)
+    verbose : bool, optional
+        Specify whether to print console output (Default: False)
+
+    Returns
+    -------
+    None; writes out file
+    """
+    if not op.exists(input):
+        raise OSError('Input path does not exist. Please ensure that '
+                      'the folder or file specified exists.')
+    if not op.exists(op.dirname(output)):
+        raise OSError('Specifed directory for output file {} does not '
+                      'exist. Please ensure that this is a valid '
+                      'directory.'.format(op.dirname(output)))
+    if not (nthreads is None):
+        if not isinstance(nthreads, int):
+            raise Exception('Please specify the number of threads as an '
+                            'integer.')
+    if not isinstance(force, bool):
+        raise Exception('Please specify whether forced overwrite is True '
+                        'or False.')
+    if not isinstance(verbose, bool):
+        raise Exception('Please specify whether verbose is True or False.')
+    outdir = op.dirname(output)
+    fname_bzero = op.join(outdir, 'B0_ALL.mif')
+    # Extract all B0s
+    extractbzero(input, fname_bzero, nthreads=nthreads, force=force,
+              verbose=verbose)
+    arg = (['mrmath', '-axis', '3', fname_bzero, 'mean', output])
+    completion = subprocess.run(arg)
+    if completion.returncode != 0:
+        raise Exception('Unable to extract B0s from DWI for computation '
+                        'of brain mask. See above for errors.')
+    # Remove non-essential files
+    os.remove(fname_bzero)
+
 def extractnonbzero(input, output, nthreads=None, force=False,
               verbose=False):
     """

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -686,7 +686,7 @@ def main():
         files = []
         files.append(init_nii)
         files.append(filetable['HEAD'].getFull())
-        if not filetable['mask'] is None:
+        if 'mask' in filetable:
             snr = snrplot.makesnr(dwilist=files,
                                   noisepath=nii_noisemap,
                                   maskpath=filetable['mask'].getFull())
@@ -724,7 +724,7 @@ def main():
                 outlier_plot_full = op.join(qcpath,
                                     'outliers.png')
                 dp.writeNii(outliers, img.hdr, outlier_full)
-                if not filetable['mask'] is None:
+                if 'mask' in filetable:
                     outlierplot.plot(input=outlier_full,
                                     output=outlier_plot_full,
                                     bval=filetable['HEAD'].getBVAL(),

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -706,7 +706,28 @@ def main():
         # update nifti file tracking
         filetable['rician_corrected'] = DWIFile(nii_rician)
         filetable['HEAD'] = filetable['rician_corrected']
-                
+
+    #-----------------------------------------------------------------
+    # Extract averaged B0
+    #-----------------------------------------------------------------
+    # file names
+    b0_name = 'B0'
+    nii_b0 = op.join(outpath, b0_name + '.nii')
+    # check to see if this already exists
+    if not (args.resume and op.exists(nii_b0)):
+        # extract mean B0
+        mrpreproc.extractmeanbzero(input=working_path,
+                                    output=nii_b0,
+                                    nthreads=args.nthreads,
+                                    force=args.force,
+                                    verbose=args.verbose)
+        # update command history
+        cmdtable['B0'] = mrinfoutil.commandhistory(working_path)[-1]
+        cmdtable['HEAD'] = cmdtable['B0']
+    # update nifti file tracking
+    filetable['B0'] = DWIFile(nii_b0)
+    filetable['HEAD'] = filetable['B0']
+
     #-----------------------------------------------------------------
     # Make preprocessed file
     #-----------------------------------------------------------------

--- a/docs/source/reference/pydesigner_args.rst
+++ b/docs/source/reference/pydesigner_args.rst
@@ -28,6 +28,10 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 --extent        Shape of denoising extent matrix, defaults to 5,5,5
 
+--reslice       Reslices input DWI and outputs to a specific resolution in mm
+
+--interp        The interpolation method to use when resizing
+
 --degibbs       Corrects Gibb’s ringing
 
 --undistort     Undistorts image using a suite of EPI distortion correction, eddy current correction, and co-registration. Does not run EPI correction if reverse phase encoding DWI is absent.


### PR DESCRIPTION
This PR closes #193 by creating a the new function `designer.preprocessing.mrpreproc.extractmeanbzero()` that does nothing but create an averaged B0 free of NaNs. Brain masking did this previously, so a B0.nii would only be created if users provided a `--mask` flag. Create a separate function to do just this allows PyDesigner to produce brain mask and B0 images independently.

A new reslicing feature has also been introduced that users can access with the `--reslice [x,y,z]` flag, where voxel size is provided in all 3 planes in millimeters (mm). Users may optionally provide the `--interp [type]`flag to choose type of interpolation. Reslicing, if used, occurs immediately after dwnoising. This feature allows batch processing of multi-scanner data by producing voxels of consistent size regardless of input.

A bug when no mask option is provided with denoise would produce an error at SNR plot. The test to check whether a brain mask exists has been improved.