### PR TITLE
Multi TE support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,39 @@ Changelog
 All notable changes to this project will be documented in this file or
 page
 
+`v1.0-RC10`_
+-----------
+
+Jun 16, 2021
+
+**Added**:
+
+* Support for multi echo time (TE) datasets. PyDesigner will now
+  preprocess DWIs with multiple TEs together, but extract diffusion
+  metrics for each TE separately. Users need to parse :code:`-te`
+  flag to enable this feature.
+* Added :code:`dwiextract` function to *mrpreproc.py* to allowing
+  splitting of *.mif* files.
+* Added function :code:`fit_regime` to *dwipy.py* to automatically run
+  all tensor fitting steps in an appropriate manner.
+* Added :code:`highprecisionpower` to *dwipy.py* to mitigate integer
+  overflow error when performing FBI fODF calculation.
+
+
+**Changed**
+
+* Maximum DKI b-value threshold has been raised to 3,000 mm/s^2,
+  thereby enabling DKI support for researchers using b-values higher
+  than 2,000 mm/s^2 but less than 3,000 mm/s^2.
+* IRLLS now also includes B0 volumes when evaluating goodness-of-fit
+  to make outlier detection more robust and accurate.
+* Various stability patches for FBI and FBWM to ensure error-free
+  extraction of FBI/FBWM metrics.
+
+**Removed**
+
+* None
+
 `v1.0-RC9`_
 -----------
 
@@ -29,7 +62,7 @@ Feb 15, 2021
 
 **Added**:
 
-* Added missing Rician preprocessing to `-s, --standard`
+* Added missing Rician preprocessing to :code:`-s, --standard`
   preprocessing
 
 **Changed**
@@ -331,6 +364,7 @@ Initial port of MATLAB code to Python. 200,000,000,000 BCE
 
 .. Links
 
+.. _v1.0-RC10: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC10
 .. _v1.0-RC9: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC9
 .. _v1.0-RC8: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC8
 .. _v1.0-RC7: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC7

--- a/designer/fitting/dwi_fnames.py
+++ b/designer/fitting/dwi_fnames.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+_dti_ = {
+    'md': 'dti_md',
+    'rd': 'dti_rd',
+    'ad': 'dti_ad',
+    'fa': 'dti_fa',
+    'fe': 'dti_fe',
+    'trace': 'dti_tract'
+}
+
+_dki_ = {
+    'mk': 'dki_mk',
+    'rk': 'dki_rk',
+    'ak': 'dki_ak',
+    'kfa': 'dki_kfa',
+    'mkt': 'dki_mkt',
+    'trace': 'dki_trace'
+}
+
+_wmti_ = {
+    'awf': 'wmti_awf',
+    'eas_ad': 'wmti_eas_ad',
+    'eas_rd': 'wmti_eas_rd',
+    'eas_tort': 'wmti_eas_tort',
+    'ias_da': 'wmti_ias_da'
+}
+
+_fbi_ = {
+    'zeta': 'fbi_zeta',
+    'faa': 'fbi_faa',
+    'sph': 'fbi_fodf',
+    'tract': 'fbi_tractography_dsi',
+    'awf': 'fbwm_awf',
+    'Da': 'fbwm_da',
+    'De_mean': 'fbwm_de_mean',
+    'De_ax': 'fbwm_de_ax',
+    'De_rad': 'fbwm_de_rad',
+    'fae': 'fbwm_fae',
+    'min_cost': 'fbwm_minCost',
+    'min_cost_fn': 'fbwm_minCost_FN'
+}
+
+_tensor_ = {
+    'DT': 'DT',
+    'KT': 'KT'
+}

--- a/designer/fitting/dwi_fnames.py
+++ b/designer/fitting/dwi_fnames.py
@@ -7,7 +7,7 @@ _dti_ = {
     'ad': 'dti_ad',
     'fa': 'dti_fa',
     'fe': 'dti_fe',
-    'trace': 'dti_tract'
+    'trace': 'dti_trace'
 }
 
 _dki_ = {
@@ -45,4 +45,9 @@ _fbi_ = {
 _tensor_ = {
     'DT': 'DT',
     'KT': 'KT'
+}
+
+_outliers_ = {
+    'IRLLS': 'outliers_irlls',
+    'AKC': 'outliers_akc'
 }

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1374,7 +1374,7 @@ class DWI(object):
             alm = np.dot(np.linalg.pinv(B),(dwi/b0)) # DWI signal SH coefficients (these are complex)
             alm[np.isnan(alm)] = 0
             a00 = alm[0].real # the imaginary part is on the order of 10^-18 (this is for zeta)
-            clm = alm*gl[0]*highprecisionpower(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
+            clm = alm*gl[0]*np.power(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
             # need to figure out how to do peak detection (on this variable and then read out odf structures like in MATLAB code)
             # only the real part would be read out but that would need to be done later on after the rectification process below
             ODF = np.matmul(H,clm)
@@ -2960,39 +2960,5 @@ def highprecisionexp(array, maxp=1e32):
         ans = np.exp(array)
     except:
         ans = np.full(array.shape, maxp)
-    np.seterr(**defaultErrorState)
-    return ans
-
-def highprecisionpower(x1, x2, maxp=1e32):
-    """
-    Prevents overflow warning with numpy.power by assigning overflows
-    to a maxumum precision value. Raise each base in x1 to the
-    positionally-corresponding power in x2.
-    Classification: Function
-
-    Parameters
-    ----------
-    x1 : ndarray
-        Array or scalar of bases
-    x2: ndarray
-        Array or scalar of exponents
-    maxp : float, optional
-        Maximum preicison to assign if overflow (Default: 1e32)
-
-    Returns
-    -------
-    exponent or max-precision
-
-    Examples
-    --------
-    a = highprecisionexp(array)
-    """
-    np.seterr(all='ignore')
-    defaultErrorState = np.geterr()
-    np.seterr(over='raise', invalid='raise')
-    try:
-        ans = np.power(x1, x2)
-    except:
-        ans = np.full(x1.shape, maxp)
     np.seterr(**defaultErrorState)
     return ans

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1374,7 +1374,7 @@ class DWI(object):
             alm = np.dot(np.linalg.pinv(B),(dwi/b0)) # DWI signal SH coefficients (these are complex)
             alm[np.isnan(alm)] = 0
             a00 = alm[0].real # the imaginary part is on the order of 10^-18 (this is for zeta)
-            clm = alm*gl[0]*np.power(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
+            clm = alm*gl[0]*highprecisionpower(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
             # need to figure out how to do peak detection (on this variable and then read out odf structures like in MATLAB code)
             # only the real part would be read out but that would need to be done later on after the rectification process below
             ODF = np.matmul(H,clm)
@@ -2960,5 +2960,39 @@ def highprecisionexp(array, maxp=1e32):
         ans = np.exp(array)
     except:
         ans = np.full(array.shape, maxp)
+    np.seterr(**defaultErrorState)
+    return ans
+
+def highprecisionpower(x1, x2, maxp=1e32):
+    """
+    Prevents overflow warning with numpy.power by assigning overflows
+    to a maxumum precision value. Raise each base in x1 to the
+    positionally-corresponding power in x2.
+    Classification: Function
+
+    Parameters
+    ----------
+    x1 : ndarray
+        Array or scalar of bases
+    x2: ndarray
+        Array or scalar of exponents
+    maxp : float, optional
+        Maximum preicison to assign if overflow (Default: 1e32)
+
+    Returns
+    -------
+    exponent or max-precision
+
+    Examples
+    --------
+    a = highprecisionexp(array)
+    """
+    np.seterr(all='ignore')
+    defaultErrorState = np.geterr()
+    np.seterr(over='raise', invalid='raise')
+    try:
+        ans = np.power(x1, x2)
+    except:
+        ans = np.full(x1.shape, maxp)
     np.seterr(**defaultErrorState)
     return ans

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -15,6 +15,7 @@ from scipy.special import sph_harm, gamma, hyp1f1, factorial
 from tqdm import tqdm
 from . import dwidirs
 from . import thresholds as th
+from . import dwi_fnames
 from designer.plotting import outlierplot
 
 # Define the lowest number possible before it is considered a zero
@@ -2703,25 +2704,25 @@ def fit_regime(input, output,
     img = DWI(input, mask=mask, nthreads=nthreads)
     protocols = img.tensorType()
     print('Protocol(s) detected: {}' .format(', '.join([x.upper() for x in protocols])))
-    from . import dwi_fnames
-    fname_dti = dwi_fnames._dti_
-    fname_dki = dwi_fnames._dki_
-    fname_wmti = dwi_fnames._wmti_
-    fname_fbi = dwi_fnames._fbi_
-    fname_tensor = dwi_fnames._tensor_
-    fname_outliers = dwi_fnames._outliers_
-    for key, value in fname_dti.copy().items():
+    fname_dti = {}
+    fname_dki = {}
+    fname_wmti = {}
+    fname_fbi = {}
+    fname_tensor = {} 
+    fname_outliers = {}
+    for key, value in dwi_fnames._dti_.items():
         fname_dti[key] = prefix + value + suffix + ext
-    for key, value in fname_dki.copy().items():
+    for key, value in dwi_fnames._dki_.items():
         fname_dki[key] = prefix + value + suffix + ext
-    for key, value in fname_wmti.copy().items():
+    for key, value in dwi_fnames._wmti_.items():
         fname_wmti[key] = prefix + value + suffix + ext
-    for key, value in fname_fbi.copy().items():
+    for key, value in dwi_fnames._fbi_.items():
         fname_fbi[key] = prefix + value + suffix + ext
-    for key, value in fname_tensor.copy().items():
+    for key, value in dwi_fnames._tensor_.items():
         fname_tensor[key] = prefix + value + suffix + ext
-    for key, value in fname_outliers.copy().items():
+    for key, value in dwi_fnames._outliers_.items():
         fname_outliers[key] = prefix + value + suffix + ext
+    print(fname_dki)
     if irlls:
         if img.isdki():
             outliers, dt_est = img.irlls(mode='DKI', excludeb0=False)

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1374,7 +1374,7 @@ class DWI(object):
             alm = np.dot(np.linalg.pinv(B),(dwi/b0)) # DWI signal SH coefficients (these are complex)
             alm[np.isnan(alm)] = 0
             a00 = alm[0].real # the imaginary part is on the order of 10^-18 (this is for zeta)
-            clm = alm*gl[0]*np.power(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
+            clm = alm*gl[0]*highprecisionpower(np.sqrt(4*np.pi)*alm[0]*Pl0*gl,-1) # fODF SH coefficients (these are complex)
             # need to figure out how to do peak detection (on this variable and then read out odf structures like in MATLAB code)
             # only the real part would be read out but that would need to be done later on after the rectification process below
             ODF = np.matmul(H,clm)
@@ -2960,5 +2960,38 @@ def highprecisionexp(array, maxp=1e32):
         ans = np.exp(array)
     except:
         ans = np.full(array.shape, maxp)
+    np.seterr(**defaultErrorState)
+    return ans
+
+def highprecisionpower(x1, x2, maxp=1e32):
+    """
+    Prevents overflow warning with numpy.powerr by assigning overflows
+    to a maxumum precision value
+    Classification: Function
+
+    Parameters
+    ----------
+    x1 : array_like
+        The bases
+    x2 : array_like
+        The exponents
+    maxp : float, optional
+        Maximum preicison to assign if overflow (Default: 1e32)
+
+    Returns
+    -------
+    x1 raised to x2 power, or max precision defined by maxp
+
+    Examples
+    --------
+    a = highprecisionexp(array)
+    """
+    np.seterr(all='ignore')
+    defaultErrorState = np.geterr()
+    np.seterr(over='raise', invalid='raise')
+    try:
+        ans = np.power(x1, x2)
+    except:
+        ans = np.full(x1.shape, maxp)
     np.seterr(**defaultErrorState)
     return ans

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -213,7 +213,24 @@ class DWI(object):
         a = dwi.maxDKIBval(), where dwi is the DWI class object
 
         """
-        exclude_idx = self.grad[:, 3] < th.__maxdkibval__
+        exclude_idx = self.grad[:, 3] <= th.__maxdkibval__
+        return max(np.unique(self.grad[exclude_idx,3])).astype(int)
+
+    def maxFBIBval(self):
+        """
+        Returns the maximum FBI b-value in a dataset
+
+        Returns
+        -------
+        float
+            maximum DKI B-value in DWI
+
+        Examples
+        --------
+        a = dwi.maxDKIBval(), where dwi is the DWI class object
+
+        """
+        exclude_idx = self.grad[:, 3] <= th.__maxfbibval__
         return max(np.unique(self.grad[exclude_idx,3])).astype(int)
 
     def idxb0(self):

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -196,7 +196,7 @@ class DWI(object):
         a = dwi.maxDKIBval(), where dwi is the DWI class object
 
         """
-        exclude_idx = self.grad[:, 3] < th.__maxdtibval__
+        exclude_idx = self.grad[:, 3] <= th.__maxdtibval__
         return max(np.unique(self.grad[exclude_idx,3])).astype(int)
     
     def maxDKIBval(self):
@@ -291,7 +291,7 @@ class DWI(object):
         """
         idx = np.ones_like(self.grad[:, 3], dtype=bool)
         if self.isfbi():
-            idx = self.grad[:, -1] >= th.__minfbibval__
+            idx = np.rint(self.grad[:, -1]) == np.rint(self.maxFBIBval())
         else:
             raise IndexError('No valid FBI sequence found.')
         return idx

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -311,13 +311,13 @@ class DWI(object):
         a = dwi.tensorType(), where dwi is the DWI class object
         """
         type = []
-        if self.maxDTIBval() <= 1.5 and \
-            self.maxDTIBval() > th.__mindkibval__:
+        if self.maxDTIBval() <= th.__maxdtibval__ and \
+            self.maxDTIBval() >= th.__mindkibval__:
             type.append('dti')
-        if self.maxDKIBval() > 1.5 and \
-            self.maxDKIBval() < th.__maxdkibval__:
+        if self.maxDKIBval() >= th.__maxdtibval__ and \
+            self.maxDKIBval() <= th.__maxdkibval__:
             type.append('dki')
-        if self.maxBval() >= th.__maxdkibval__:
+        if self.maxBval() >= th.__minfbibval__:
             type.append('fbi')
         if 'fbi' in type and 'dki' in type:
             type.append('fbwm')

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -2724,9 +2724,9 @@ def fit_regime(input, output,
         fname_outliers[key] = prefix + value + suffix + ext
     if irlls:
         if img.isdki():
-            outliers, dt_est = img.irlls(mode='DKI')
+            outliers, dt_est = img.irlls(mode='DKI', excludeb0=False)
         else:
-            outliers, dt_est = img.irlls(mode='DTI')
+            outliers, dt_est = img.irlls(mode='DTI', excludeb0=False)
         if qcpath:
             if op.exists(qcpath):
                 outlier_full = op.join(qcpath, fname_outliers['IRLLS'])

--- a/designer/fitting/thresholds.py
+++ b/designer/fitting/thresholds.py
@@ -1,8 +1,9 @@
-__maxdtibval__ = 1.5    # maximum DTI B-value
 __mindtibval__ = 0.5    # minimum DTI B-value
-__maxdkibval__ = 2.5    # minimum DTI B-value
-__mindkibval__ = 0.5    # maximum DKI B-value
+__maxdtibval__ = 1.5    # maximum DTI B-value
+__mindkibval__ = 0.5    # minimum DKI B-value
+__maxdkibval__ = 3.0    # maximum DKI B-value
 __minfbibval__ = 4.0    # minimum FBI B-value
+__maxfbibval__ = 12.0    # maximum FBI B-value
 __d0__ = 3.0            # diffusivity of free water at body temp (37 deg C) for upper bound on Da
 __dn__ = 1.5            # estimated intra-neurite diffusivity in mm^2/ms
 __pkT__ = 0.4           # peak thresholding for white matter fiber tracking

--- a/designer/info.py
+++ b/designer/info.py
@@ -10,9 +10,9 @@ __execdir__ = os.path.basename(
     )
 )
 __packagename__ = 'PyDesigner'
-__version__='v1.0-RC9'
+__version__='v1.0-RC10'
 __author__ = 'PyDesigner developers'
-__copyright__ = 'Copyright 2020, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
+__copyright__ = 'Copyright 2021, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
 __credits__ = [
     'Siddhartha Dhiman',
     'Joshua Teves',

--- a/designer/preprocessing/mrinfoutil.py
+++ b/designer/preprocessing/mrinfoutil.py
@@ -501,3 +501,43 @@ def is_fullsphere(path):
             return True
         else:
             return False
+
+def echotime(path):
+    """
+    Returns the echo time(s) of DWI in miliseconds
+
+    Parameters
+    ----------
+    path : str
+        Path to input image or directory
+
+    Returns
+    -------
+    int if all DWIs have the same echo time
+        Echo time in miliseconds
+    str if all DWIs have different echo time
+        'variable'
+    """
+    if not op.exists(path):
+        raise OSError('Input path does not exist. Please ensure that the '
+                      'folder or file specified exists.')
+    ftype = format(path)
+    if ftype != 'MRtrix':
+        raise IOError('This function only works with MRtrix (.mif) '
+                      'formatted filetypes. Please ensure that the input '
+                      'filetype meets this requirement')
+    arg = ['mrinfo', '-property', 'EchoTime']
+    arg.append(path)
+    completion = subprocess.run(arg, stdout=subprocess.PIPE)
+    if completion.returncode != 0:
+        raise IOError('Input {} is not currently supported by '
+                      'PyDesigner.'.format(path))
+    console = str(completion.stdout).split('\\n')[0]
+    console = console.split('b')[-1]
+    console = console.replace("'", "")
+    try:
+        console = float(console)
+        console = int(round(console * 1000, 0))
+    except:
+        console = 'variable'
+    return console

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -330,7 +330,11 @@ class DWIParser:
     JSONlist : list of str
         Contains paths to all JSON files
     nDWI : int
-        Number of DWIs entered   
+        Number of DWIs entered
+    echotime : list of int
+        Echo time in miliseconds of each input DWI
+    vols : list of ints
+        Number of volumes in each input DWI
     """
     def __init__(self, path):
         """
@@ -423,6 +427,7 @@ class DWIParser:
         if not (resume and op.exists(op.join(path, 'working' + ext))):
             miflist = []
             # The following loop converts input file into .mif
+            echotime = []
             for (idx, i) in enumerate(self.DWIlist):
                 if 'nifti' in self.InputType and \
                         (not (op.exists(self.BVEClist[idx])) or \
@@ -528,8 +533,14 @@ class DWIParser:
                                     'and .json. If this is not possible, '
                                     'please provide manually concatenated '
                                     'DWIs or run with single series input.')
+            echotime = []
+            vols = []
             for i, fname in enumerate(miflist):
+                echotime.append(mrinfoutil.echotime(fname))
+                vols.append(mrinfoutil.size(fname)[-1])
                 os.remove(fname)
+            self.echotime = echotime
+            self.vols = vols
 
     def getPath(self):
         """

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -301,6 +301,11 @@ class DWIFile:
                         return False
                     else:
                         return True
+                else:
+                    print('Insufficient information in .json file to '
+                    'determine Fourier status. Assuming DWI is '
+                    'partial Fourier')
+                    return True
 
     def print(self, json=False):
         print('Path: ' + self.path)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -206,7 +206,7 @@ def main():
                         'While maps appear visually soother with '
                         'this flag on, they may nonetheless be less '
                         'accurate.')
-    parser.add_argument('--nthreads', type=int,
+    parser.add_argument('--nthreads', type=int, default=None,
                         help='Number of threads to use for computation. '
                         'Note that using too many threads will cause a slow-'
                         'down.')
@@ -272,11 +272,10 @@ def main():
                         nthreads=args.nthreads,
                         force=args.force,
                         verbose=args.verbose)
-
+                        
     #-----------------------------------------------------------------
     # Validate Arguments
     #-----------------------------------------------------------------
-
     errmsg = ''
     warningmsg = ''
     msgstart = 'Incompatible arguments: '
@@ -770,8 +769,6 @@ def main():
                             verbose=False)
     filetable['preprocessed'] = DWIFile(preprocessed)
     filetable['HEAD'] = filetable['preprocessed']
-    # Remove working.mif
-    os.remove(working_path)
 
     #-----------------------------------------------------------------
     # Compute SNR

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -7,6 +7,7 @@ Runs the PyDesigner pipeline
 #---------------------------------------------------------------------
 import sys as sys
 import subprocess #subprocess
+import glob # recursive file search
 import os # mkdir
 import os.path as op # path
 import shutil # which, rmtree
@@ -785,235 +786,75 @@ def main():
     #-----------------------------------------------------------------
     # Tensor Fitting
     #-----------------------------------------------------------------
+    ext = '.nii'
+    fit_mask = None
+    if 'mask' in filetable:
+        fit_mask = filetable['mask'].getFull()
     if not args.nofit:
         # create dwi fitting object
-        if not args.nthreads:
-            img = dp.DWI(
-                imPath=filetable['HEAD'].getFull(),
-            )
+        if multi_echo and args.multite:
+            for path, echo in zip(imPath, image.echotime):
+                # qcpath = op.join(op.dirname(path), 'qc_fitting')
+                os.makedirs(qcpath, exist_ok=True)
+                dp.fit_regime(
+                    input=path,
+                    output=metricpath,
+                    prefix='TE' + str(echo) + '_',
+                    suffix=None,
+                    ext=ext,
+                    irlls=not args.nooutliers,
+                    akc=not args.noakc,
+                    l_max=args.l_max,
+                    qcpath=fitqcpath,
+                    fit_constraints=fit_constraints,
+                    mask=fit_mask,
+                    nthreads=args.nthreads
+                )
         else:
-            img = dp.DWI(
-                imPath=filetable['HEAD'].getFull(),
+            dp.fit_regime(
+                input=imPath,
+                output=metricpath,
+                prefix=None,
+                suffix=None,
+                ext=ext,
+                irlls=not args.nooutliers,
+                akc=not args.noakc,
+                l_max=args.l_max,
+                qcpath=fitqcpath,
+                fit_constraints=fit_constraints,
+                mask=fit_mask,
                 nthreads=args.nthreads
             )
-        protocols = img.tensorType()
-        print('Protocol(s) detected: {}' .format(', '.join([x.upper() for x in protocols])))
-        # Define filenames
-        fn_dti_md = 'dti_md'
-        fn_dti_rd = 'dti_rd'
-        fn_dti_ad = 'dti_ad'
-        fn_dti_fa = 'dti_fa'
-        fn_dti_fe = 'dti_fe'
-        fn_dki_mk = 'dki_mk'
-        fn_dki_rk = 'dki_rk'
-        fn_dki_ak = 'dki_ak'
-        fn_dki_kfa = 'dki_kfa'
-        fn_dki_mkt = 'dki_mkt'
-        if img.isdki():
-            fn_trace = 'dki_trace'
+
+    #-----------------------------------------------------------------
+    # Post Processing
+    #-----------------------------------------------------------------
+    if args.median:
+        f_metrics = glob.glob(op.join(metricpath, '*' + ext))
+        f_metrics = [x for x in f_metrics if not x.endswith('DT.nii')]
+        f_metrics = [x for x in f_metrics if not x.endswith('KT.nii')]
+        f_metrics = [x for x in f_metrics if not x.endswith('fodf.nii')]
+        for f in f_metrics:
+            filters.median(f, f)
+
+    #-----------------------------------------------------------------
+    # Fiber Tracking
+    #-----------------------------------------------------------------
+    f_odf = glob.glob(op.join(metricpath, '*fodf*'))
+    for f in f_odf:
+        if 'mask' in filetable:
+            path, ext = op.splitext(f)
+            f_fib = path + '_tractography_dsi.fib'
+            ds.makefib(
+                input=f,
+                output=f_fib,
+                mask=filetable['mask'].getFull()
+            )
         else:
-            fn_trace = 'dti_trace'
-        fn_wmti_awf = 'wmti_awf'
-        fn_wmti_eas_ad = 'wmti_eas_ad'
-        fn_wmti_eas_rd = 'wmti_eas_rd'
-        fn_wmti_eas_tort = 'wmti_eas_tort'
-        fn_wmti_ias_da = 'wmti_ias_da'
-        fn_fbi_zeta = 'fbi_zeta'
-        fn_fbi_faa = 'fbi_faa'
-        fn_fbi_sph = 'fbi_fodf'
-        fn_fbi_tract = 'fbi_tractography_dsi'
-        fn_fbi_awf = 'fbwm_awf'
-        fn_fbi_Da = 'fbwm_da'
-        fn_fbi_De_mean = 'fbwm_de_mean'
-        fn_fbi_De_ax = 'fbwm_de_ax'
-        fn_fbi_De_rad = 'fbwm_de_rad'
-        fn_fbi_fae = 'fbwm_fae'
-        fn_fbi_min_cost = 'fbwm_minCost'
-        fn_fbi_min_cost_fn = 'fbwm_minCost_FN'
-        fn_DT = 'DT'
-        fn_KT = 'KT'
-        fn_ext = '.nii'
-
-        if img.isdki() or img.isdti():
-            # detect outliers
-            if not args.nooutliers:
-                if img.isdki():
-                    outliers, dt_est = img.irlls(mode='DKI')
-                else:
-                    outliers, dt_est = img.irlls(mode='DTI')
-                # write outliers to qc folder
-                if not args.noqc:
-                    outlier_full = op.join(fitqcpath, 'outliers_irlls.nii')
-                    outlier_plot_full = op.join(qcpath,
-                                        'outliers.png')
-                    bvals_outlier_full = op.join(fitqcpath, 'outliers.bval')
-                    if img.isdki():
-                        bvals_outlier = img.getBvals()[img.idxdki()].astype(int)
-                    else:
-                        bvals_outlier = img.getBvals()[img.idxdti()].astype(int)
-                    bvals_outlier = bvals_outlier * 1000
-                    dp.writeNii(outliers, img.hdr, outlier_full)
-                    np.savetxt(bvals_outlier_full, bvals_outlier, newline=' ', fmt="%d")
-                    if 'mask' in filetable:
-                        outlierplot.plot(input=outlier_full,
-                                        output=outlier_plot_full,
-                                        bval=bvals_outlier_full,
-                                        mask=filetable['mask'].getFull())
-                    else:
-                        outlierplot.plot(input=outlier_full,
-                                        output=outlier_plot_full,
-                                        bval=bvals_outlier_full,
-                                        mask=None)
-                    os.remove(bvals_outlier_full)
-                # fit while rejecting outliers
-                img.fit(fit_constraints, reject=outliers)
-            else:
-                # fit without rejecting outliers
-                img.fit(fit_constraints)
-            
-            if (img.isdti() or img.isdki()) and not args.noakc:
-                akc_out = img.akcoutliers()
-                img.akccorrect(akc_out)
-                if not args.noqc:
-                    dp.writeNii(akc_out,
-                                img.hdr,
-                                op.join(fitqcpath, 'outliers_akc'))
-
-             # reorder tensor for mrtrix3
-            if 'dki' in img.tensorType():
-                tensorType = 'dki'
-            else:
-                tensorType = 'dti'
-            DT, KT = img.tensorReorder(tensorType)
-            if tensorType == 'dki':
-                dp.writeNii(DT, img.hdr, op.join(metricpath, fn_DT))
-                dp.writeNii(KT, img.hdr, op.join(metricpath, fn_KT))
-            else:
-                dp.writeNii(DT, img.hdr, op.join(metricpath, fn_DT))
-
-            md, rd, ad, fa, fe, trace = img.extractDTI()
-            dp.writeNii(md, img.hdr, op.join(metricpath, fn_dti_md))
-            dp.writeNii(rd, img.hdr, op.join(metricpath, fn_dti_rd))
-            dp.writeNii(ad, img.hdr, op.join(metricpath, fn_dti_ad))
-            dp.writeNii(fa, img.hdr, op.join(metricpath, fn_dti_fa))
-            dp.writeNii(fe, img.hdr, op.join(metricpath, fn_dti_fe))
-            if args.median:
-                for x in [fn_dti_md, fn_dti_rd, fn_dti_ad, fn_dti_fa, fn_dti_fe]:
-                    filters.median(
-                        input=op.join(metricpath, x + fn_ext),
-                        output=op.join(metricpath, x + fn_ext),
-                        mask=filetable['mask'].getFull())
-            if not img.isdki():
-                dp.writeNii(trace, img.hdr, op.join(metricpath, fn_trace))
-                filters.median(
-                    input=op.join(metricpath, fn_trace + fn_ext),
-                    output=op.join(metricpath, fn_trace + fn_ext),
-                    mask=filetable['mask'].getFull())
-            else:
-                mk, rk, ak, kfa, mkt, trace = img.extractDKI()
-                # naive implementation of writing these variables
-                dp.writeNii(mk, img.hdr, op.join(metricpath, fn_dki_mk))
-                dp.writeNii(rk, img.hdr, op.join(metricpath, fn_dki_rk))
-                dp.writeNii(ak, img.hdr, op.join(metricpath, fn_dki_ak))
-                dp.writeNii(kfa, img.hdr, op.join(metricpath, fn_dki_kfa))
-                dp.writeNii(mkt, img.hdr, op.join(metricpath, fn_dki_mkt))
-                dp.writeNii(trace, img.hdr, op.join(metricpath, fn_trace))
-                if args.median:
-                    for x in [fn_dki_mk, fn_dki_rk, fn_dki_ak, fn_dki_kfa, fn_dki_mkt, fn_trace]:
-                        filters.median(
-                            input=op.join(metricpath, x + fn_ext),
-                            output=op.join(metricpath, x + fn_ext),
-                            mask=filetable['mask'].getFull())
-                # Perform WMTI calcualtions           
-                awf, eas_ad, eas_rd, eas_tort, ias_da = \
-                    img.extractWMTI()
-                dp.writeNii(awf, img.hdr,
-                            op.join(metricpath, fn_wmti_awf))
-                dp.writeNii(eas_ad, img.hdr,
-                            op.join(metricpath, fn_wmti_eas_ad))
-                dp.writeNii(eas_rd, img.hdr,
-                            op.join(metricpath, fn_wmti_eas_rd))
-                dp.writeNii(eas_tort, img.hdr,
-                            op.join(metricpath, fn_wmti_eas_tort))
-                dp.writeNii(ias_da, img.hdr,
-                            op.join(metricpath, fn_wmti_ias_da))
-                if args.median:
-                    for x in [
-                        fn_wmti_awf,
-                        fn_wmti_eas_ad,
-                        fn_wmti_eas_rd,
-                        fn_wmti_eas_tort,
-                        fn_wmti_ias_da
-                    ]:
-                        filters.median(
-                            input=op.join(metricpath, x + fn_ext),
-                            output=op.join(metricpath, x + fn_ext),
-                            mask=filetable['mask'].getFull())
-        if img.isfbi():
-            if img.isfbwm():
-                zeta, faa, sph, min_awf, Da, De_mean, De_ax, De_rad, De_fa, min_cost, min_cost_fn = img.fbi(l_max=args.l_max, fbwm=True)
-                dp.writeNii(zeta, img.hdr,
-                        op.join(metricpath, fn_fbi_zeta))
-                dp.writeNii(faa, img.hdr,
-                        op.join(metricpath, fn_fbi_faa))
-                dp.writeNii(sph, img.hdr,
-                        op.join(metricpath, fn_fbi_sph))
-                dp.writeNii(min_awf, img.hdr,
-                        op.join(metricpath, fn_fbi_awf))
-                dp.writeNii(Da, img.hdr,
-                        op.join(metricpath, fn_fbi_Da))
-                dp.writeNii(De_mean, img.hdr,
-                        op.join(metricpath, fn_fbi_De_mean))
-                dp.writeNii(De_ax, img.hdr,
-                        op.join(metricpath, fn_fbi_De_ax))
-                dp.writeNii(De_rad, img.hdr,
-                        op.join(metricpath, fn_fbi_De_rad))
-                dp.writeNii(De_fa, img.hdr,
-                        op.join(metricpath, fn_fbi_fae))
-                dp.writeNii(min_cost, img.hdr,
-                        op.join(metricpath, fn_fbi_min_cost))
-                dp.writeNii(min_cost_fn, img.hdr,
-                        op.join(metricpath, fn_fbi_min_cost_fn))
-                if args.median:
-                    for x in [
-                        fn_fbi_zeta,
-                        fn_fbi_faa,
-                        fn_fbi_awf,
-                        fn_fbi_Da,
-                        fn_fbi_De_mean,
-                        fn_fbi_De_ax,
-                        fn_fbi_De_rad,
-                        fn_fbi_fae,
-                    ]:
-                        filters.median(
-                            input=op.join(metricpath, x + fn_ext),
-                            output=op.join(metricpath, x + fn_ext),
-                            mask=filetable['mask'].getFull())
-            else:
-                zeta, faa, sph, min_awf, Da, De_mean, De_ax, De_rad, De_fa, min_cost, min_cost_fn = img.fbi(l_max=args.l_max, fbwm=False)
-                dp.writeNii(zeta, img.hdr,
-                    op.join(metricpath, fn_fbi_zeta))
-                dp.writeNii(faa, img.hdr,
-                        op.join(metricpath, fn_fbi_faa))
-                dp.writeNii(sph, img.hdr,
-                        op.join(metricpath, fn_fbi_sph))
-                if args.median:
-                    for x in [fn_fbi_zeta, fn_fbi_faa]:
-                        filters.median(
-                            input=op.join(metricpath, x + fn_ext),
-                            output=op.join(metricpath, x + fn_ext),
-                            mask=filetable['mask'].getFull())
-            if 'mask' in filetable:
-                ds.makefib(
-                    input=op.join(metricpath, fn_fbi_sph + fn_ext),
-                    output=op.join(metricpath, fn_fbi_tract + '.fib'),
-                    mask=filetable['mask'].getFull()
-                )
-            else:
-                ds.makefib(
-                    input=op.join(metricpath, fn_fbi_sph + fn_ext),
-                    output=op.join(metricpath, fn_fbi_tract + '.fib'),
-                    mask=None
-                )
+            ds.makefib(
+                input=f,
+                output=f_fib,
+                mask=None
+            )
 if __name__ == '__main__':
     main()

--- a/docs/source/api/designer.fitting.dwi_fnames.rst
+++ b/docs/source/api/designer.fitting.dwi_fnames.rst
@@ -1,0 +1,4 @@
+.. automodule:: designer.fitting.dwi_fnames
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/designer.fitting.rst
+++ b/docs/source/api/designer.fitting.rst
@@ -12,6 +12,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   designer.fitting.dwi_fnames
    designer.fitting.dwidirs
    designer.fitting.dwipy
    designer.fitting.thresholds


### PR DESCRIPTION
This PR adds multi TE support into for datasets composed of multiple TEs. Concatenated DWI is now preprocessed together, but the tensor fitting regime extracts metric maps for each TE separately. Multi TE support primes PyDesigner for triple diffusion encoding (TDE) datasets.

FBI and FBWM has also been overhauled to make calculations more stable, and particularly close #255.

Thresholds have also been updated to more accurately classify datasets into DTI, DKI or FBI to close #254.