### PR TITLE
Add flag to disable FBI fODF rectification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ page
 `v1.0-RC10`_
 -----------
 
-Jun 16, 2021
+Jun 29, 2021
 
 **Added**:
 
@@ -21,6 +21,10 @@ Jun 16, 2021
   all tensor fitting steps in an appropriate manner.
 * Added :code:`highprecisionpower` to *dwipy.py* to mitigate integer
   overflow error when performing FBI fODF calculation.
+* Flag :code:`--no_rectify` to disable rectification of FBI fODFs. In
+  some cases where FBI acquistion is excellent, rectification can
+  degrade fODFs instead. This flag is intended to disable
+  rectification of such datasets.
 
 
 **Changed**

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -2722,7 +2722,6 @@ def fit_regime(input, output,
         fname_tensor[key] = prefix + value + suffix + ext
     for key, value in dwi_fnames._outliers_.items():
         fname_outliers[key] = prefix + value + suffix + ext
-    print(fname_dki)
     if irlls:
         if img.isdki():
             outliers, dt_est = img.irlls(mode='DKI', excludeb0=False)

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -2649,6 +2649,7 @@ def fit_regime(input, output,
                 irlls=True, akc=True, qcpath=None,
                 fit_constraints=[0,1,0],
                 l_max=None,
+                rectify=True,
                 mask=None,
                 nthreads=None):
     """
@@ -2687,6 +2688,9 @@ def fit_regime(input, output,
     l_max : int
         Maximum spherical harminic degree for FBI/FBWM fit.
         (Default: None)
+    rectify : bool
+        Specify whether to rectify FBI fODF
+        (Default: True)
     mask : str
         Path to brain mask
         (Default: None)
@@ -2803,7 +2807,7 @@ def fit_regime(input, output,
         if img.isfbwm():
             zeta, faa, sph, min_awf, Da, De_mean, De_ax, De_rad, \
                 De_fa, min_cost, min_cost_fn = \
-                    img.fbi(l_max=l_max, fbwm=True)
+                    img.fbi(l_max=l_max, fbwm=True, rectify=rectify)
             writeNii(zeta, img.hdr, op.join(output, fname_fbi['zeta']))
             writeNii(faa, img.hdr, op.join(output, fname_fbi['faa']))
             writeNii(sph, img.hdr, op.join(output, fname_fbi['sph']))
@@ -2818,7 +2822,7 @@ def fit_regime(input, output,
         else:
             zeta, faa, sph, min_awf, Da, De_mean, De_ax, De_rad, \
                 De_fa, min_cost, min_cost_fn = \
-                    img.fbi(l_max=l_max, fbwm=False)
+                    img.fbi(l_max=l_max, fbwm=False, rectify=rectify)
             writeNii(zeta, img.hdr, op.join(output, fname_fbi['zeta']))
             writeNii(faa, img.hdr, op.join(output, fname_fbi['faa']))
             writeNii(sph, img.hdr, op.join(output, fname_fbi['sph']))

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -194,6 +194,12 @@ def main():
                         metavar='n',
                         help='Maximum spherical harmonic degree for '
                         'FBI spherical harmonic expansion')
+    parser.add_argument('--no_rectify', action='store_true',
+                        default=False,
+                        help='Disable rectification of FBI fODF. Use '
+                        'only when rectification of excellent '
+                        'acquisitions results in degradation of FBI '
+                        'or FBWM metric maps')
     parser.add_argument('--noqc', action='store_true', default=False,
                         help='Disable QC saving of QC metrics')
     parser.add_argument('--median', action='store_true', default=False,
@@ -393,6 +399,11 @@ def main():
                 'avoid artifacts.Use the "--adv" flag to run forced '
                 'corrections.')
             args.degibbs = False
+    
+    # Handle FBI rectification
+    fbi_rectify = True
+    if args.no_rectify:
+        fbi_rectify = False
 
     #-----------------------------------------------------------------
     # Path Handling
@@ -839,6 +850,7 @@ def main():
                     irlls=not args.nooutliers,
                     akc=not args.noakc,
                     l_max=args.l_max,
+                    rectify = fbi_rectify,
                     qcpath=fitqcpath,
                     fit_constraints=fit_constraints,
                     mask=fit_mask,
@@ -854,6 +866,7 @@ def main():
                 irlls=not args.nooutliers,
                 akc=not args.noakc,
                 l_max=args.l_max,
+                rectify = fbi_rectify,
                 qcpath=fitqcpath,
                 fit_constraints=fit_constraints,
                 mask=fit_mask,

--- a/docs/source/reference/pydesigner_args.rst
+++ b/docs/source/reference/pydesigner_args.rst
@@ -50,6 +50,8 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 -r, --rician        Corrects Rician bias
 
+-te             Enable multi-TE support. This mode preprocesses all concatenated DWIs together, but performs tensor fitting separately.
+
 Diffusion Tensor Control
 ------------------------
 
@@ -74,6 +76,8 @@ Fiber Ball Imaging (FBI) Control
 FBI parameters may be fine-tuned with the following flags.
 
 --l_max n   Maximum spherical harmonic degree used in spherical harmonic expansion for fODF calculation
+
+--no_rectify  Disable rectification of FBI fODFs in instances where it does more harm than good. In rare instances, fODFs computed from FBI acquisitions can be degraded from rectification - this flag disables rectification for such datasets.
 
 Pipeline Control
 ----------------


### PR DESCRIPTION
In some rare instances, rectification of FBI fODFs can be degrade them instead. This is particularly true for excellent FBI acquisitions. This flag will close #256, as requested by Dr. Jensen.